### PR TITLE
Megacalc

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ python3 repl.py -e "40+2"
 I personally allow you to use: integers, floats, constants, and functions (including defining). For example:
 ```
 f(x,y)=x+y
-40 + rt(25, 5) - pi + 0.14 << f(1,2)
+40 + rt(25, 5) - pi + 0.14 / .14 << f(1,2)
 ```
 
 # Documentation
@@ -54,7 +54,7 @@ Or even: `-+--++--+-++--+++-+1 == -1`
 ## Numbers
 Internally number is mostly float (sometimes int). There are 3 types of numbers:
 - integers (example: `42`)
-- floats (example: `0.42`, exponenta is not supported)
+- floats (example: `0.42`, or even `.5` (that is simply `0.5`); exponenta is not supported)
 - hexdecimals (example: `0x5f3759df`)
 
 ## Variables

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ f(x)=x+5;x
 ```
 How do you think, what will `f(1)` return? Correct, value of `x`. `x+5` does nothing, so result of this expression will be removed from the stack after semicolon
 
+### Higher-order functions
+PyCalc supports even this. Higher-order function is a function that returns another function.
+For example: 
+```
+f(a) = y(b) = a * b
+mulBy5 = f(5)
+mulBy5(5)
+```
+This example will return `10`
+
 ### Functions calling
 To call a function, simply type `<name>(<args>)`.
 For example: `root(25, 5)`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![wakatime](https://wakatime.com/badge/user/b4a2ea9a-a721-41c8-b704-79b9b8cec646/project/3e68a432-deec-4dab-ba8a-a5f424e91eed.svg)](https://wakatime.com/badge/user/b4a2ea9a-a721-41c8-b704-79b9b8cec646/project/3e68a432-deec-4dab-ba8a-a5f424e91eed)
 # pycalc
 Simple calculator on python, written in academic purposes. Uses Sorting Station Algorithm for building reverse polish notation stack. Supports all kinds of operations python supports (except bool operations like or, not, etc. but they will be implemented as a functions of std-library), functions defining, variables declarations, etc.
 

--- a/pycalc/interpreter/interpret.py
+++ b/pycalc/interpreter/interpret.py
@@ -100,7 +100,7 @@ class Interpreter(ABCInterpreter):
         stack = Stack()
 
         for i, token in enumerate(expression):
-            if token.type in (TokenType.NUMBER, TokenType.IDENTIFIER):
+            if token.kind == TokenKind.NUMBER or token.type == TokenType.IDENTIFIER:
                 stack.append(token)
             elif token.type == TokenType.VAR:
                 stack.append(self._number(namespaces.get(token.value)))
@@ -123,7 +123,7 @@ class Interpreter(ABCInterpreter):
             elif token.kind == TokenKind.OPERATOR:
                 right, left = stack.pop(), stack.pop()
                 stack.append(self._number(
-                    float(self.executors[token.type](left.value, right.value))
+                    self.executors[token.type](left.value, right.value)
                 ))
             elif token.type == TokenType.FUNCCALL:
                 func = namespaces.get(token.value.name)
@@ -183,7 +183,7 @@ class Interpreter(ABCInterpreter):
     def _number(num: Number) -> Token:
         return Token(
             kind=TokenKind.NUMBER,
-            typeof=TokenType.NUMBER,
+            typeof=TokenType.FLOAT if isinstance(num, float) else TokenType.INTEGER,
             value=num
         )
 

--- a/pycalc/interpreter/interpret.py
+++ b/pycalc/interpreter/interpret.py
@@ -103,10 +103,10 @@ class Interpreter(ABCInterpreter):
             if token.kind == TokenKind.NUMBER or token.type == TokenType.IDENTIFIER:
                 stack.append(token)
             elif token.type == TokenType.VAR:
-                stack.append(self._number(namespaces.get(token.value)))
+                stack.append(self._token(namespaces.get(token.value)))
 
             elif token.kind == TokenKind.UNARY_OPERATOR:
-                stack.append(self._number(
+                stack.append(self._token(
                     self.unary_executors[token.type](stack.pop().value)
                 ))
 
@@ -122,14 +122,14 @@ class Interpreter(ABCInterpreter):
 
             elif token.kind == TokenKind.OPERATOR:
                 right, left = stack.pop(), stack.pop()
-                stack.append(self._number(
+                stack.append(self._token(
                     self.executors[token.type](left.value, right.value)
                 ))
             elif token.type == TokenType.FUNCCALL:
                 func = namespaces.get(token.value.name)
                 stack, args = self._get_func_args(token.value.argscount, stack)
                 call_result = func(*(arg.value for arg in args))
-                stack.append(self._number(call_result))
+                stack.append(self._token(call_result))
             elif token.type == TokenType.FUNCDEF:
                 func_namespace = namespaces.copy()
                 func_namespace.add_namespace({})
@@ -180,12 +180,25 @@ class Interpreter(ABCInterpreter):
         )
 
     @staticmethod
-    def _number(num: Number) -> Token:
-        return Token(
-            kind=TokenKind.NUMBER,
-            typeof=TokenType.FLOAT if isinstance(num, float) else TokenType.INTEGER,
-            value=num
-        )
+    def _token(num: Number) -> Token:
+        if isinstance(num, int):
+            return Token(
+                kind=TokenKind.NUMBER,
+                typeof=TokenType.INTEGER,
+                value=int(num)
+            )
+        elif isinstance(num, float):
+            return Token(
+                kind=TokenKind.NUMBER,
+                typeof=TokenType.FLOAT,
+                value=num
+            )
+        else:
+            return Token(
+                kind=TokenKind.OTHER,
+                typeof=TokenType.OTHER,
+                value=num
+            )
 
     @staticmethod
     def _get_func_args(argscount: int, stack: Stack) -> Tuple[Stack, Tokens]:

--- a/pycalc/interpreter/interpret.py
+++ b/pycalc/interpreter/interpret.py
@@ -1,7 +1,7 @@
 import operator
 from functools import reduce
 from abc import ABC, abstractmethod
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, List
 
 from pycalc.lex import tokenizer as _tokenizer
 from pycalc.stack import builder
@@ -117,7 +117,7 @@ class Interpreter(ABCInterpreter):
     def _spawn_function(self,
                         namespace: Namespace,
                         name: str,
-                        fargs: Tokens,
+                        fargs: List[str],
                         body: Stack) -> Function:
         def real_function(*args) -> Number:
             if not fargs and args:

--- a/pycalc/lex/tokenizer.py
+++ b/pycalc/lex/tokenizer.py
@@ -167,17 +167,6 @@ class Tokenizer(ABCTokenizer):
 
     @staticmethod
     def _mark_identifiers(tokens: Tokens) -> Tokens:
-        """
-        Just look for OP_EQ
-            - If token in the left:
-                - closing brace:
-                    - mark everything until opening brace as identifier
-                - variable:
-                    - mark as IDENTIFIER
-                - anything else:
-                    - raise exception
-        """
-
         output = []
         state = _ParserState.OTHER
         funcdef = FuncDef("", [])
@@ -257,8 +246,11 @@ class Tokenizer(ABCTokenizer):
 
             return get_lexeme(LexemeType.HEXNUMBER)
         elif raw_lexeme[0] in string.digits + ".":
-            if len(raw_lexeme) == raw_lexeme.count("."):
+            if len(raw_lexeme) == raw_lexeme.count(".") or raw_lexeme.count(".") > 1:
                 raise SyntaxError("invalid float: " + raw_lexeme)
+
+            if "." in raw_lexeme:
+                return get_lexeme(LexemeType.FLOAT)
 
             return get_lexeme(LexemeType.NUMBER)
         elif raw_lexeme == "(":
@@ -288,13 +280,19 @@ class Tokenizer(ABCTokenizer):
         if lexeme.type == LexemeType.NUMBER:
             return Token(
                 kind=TokenKind.NUMBER,
-                typeof=TokenType.NUMBER,
+                typeof=TokenType.INTEGER,
+                value=int(lexeme.value)
+            )
+        elif lexeme.type == LexemeType.FLOAT:
+            return Token(
+                kind=TokenKind.NUMBER,
+                typeof=TokenType.FLOAT,
                 value=float(lexeme.value)
             )
         elif lexeme.type == LexemeType.HEXNUMBER:
             return Token(
                 kind=TokenKind.NUMBER,
-                typeof=TokenType.NUMBER,
+                typeof=TokenType.INTEGER,
                 value=int(lexeme.value[2:], 16)
             )
         elif lexeme.type == LexemeType.LITERAL:

--- a/pycalc/lex/tokenizer.py
+++ b/pycalc/lex/tokenizer.py
@@ -153,7 +153,7 @@ class Tokenizer(ABCTokenizer):
 
         for token in ops:
             if token.value not in UNARY_OPERATORS:
-                raise SyntaxError(f"disallowed unary: {token.value}")
+                raise SyntaxError(f"illegal unary: {token.value}")
 
             subs += token.value == '-'
 
@@ -213,7 +213,7 @@ class Tokenizer(ABCTokenizer):
                     state = _ParserState.FUNCNAME
                     continue
                 elif token.type != TokenType.VAR:
-                    raise SyntaxError(f"disallowed argument identifier: {repr(token.value)}")
+                    raise SyntaxError(f"illegal argument identifier: {repr(token.value)}")
 
                 funcdef.args.append(token)
                 token.type = TokenType.IDENTIFIER

--- a/pycalc/stack/builder.py
+++ b/pycalc/stack/builder.py
@@ -31,7 +31,7 @@ class SortingStationBuilder(ABCBuilder):
             args_counters = self._count_args(expr)[::-1]
 
             for i, token in enumerate(expr):
-                if token.type in (TokenType.NUMBER, TokenType.IDENTIFIER):
+                if token.kind == TokenKind.NUMBER or token.type == TokenType.IDENTIFIER:
                     output.append(token)
                 elif token.type == TokenType.VAR:
                     if i < len(expr)-1 and expr[i+1].type == TokenType.LBRACE:

--- a/pycalc/stack/builder.py
+++ b/pycalc/stack/builder.py
@@ -55,6 +55,8 @@ class SortingStationBuilder(ABCBuilder):
                         stack.top.kind in (TokenKind.OPERATOR, TokenKind.UNARY_OPERATOR, TokenKind.FUNC)
                         and
                         token_priority <= priority[stack.top.type]
+                        and
+                        stack.top.type != TokenType.OP_POW
                     ):
                         output.append(stack.pop())
 

--- a/pycalc/tokentypes/tokens.py
+++ b/pycalc/tokentypes/tokens.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Union, Callable
 
 from . import types
 
@@ -65,5 +65,20 @@ class FuncDef:
 
     def __str__(self):
         return f"FuncDef(name={repr(self.name)}, args=({','.join(arg.value for arg in self.args)}))"
+
+    __repr__ = __str__
+
+
+class Function:
+    def __init__(self, name: str, target: Callable):
+        self.name = name
+        self.target = target
+
+    @property
+    def __call__(self):
+        return self.target
+
+    def __str__(self):
+        return self.name
 
     __repr__ = __str__

--- a/pycalc/tokentypes/types.py
+++ b/pycalc/tokentypes/types.py
@@ -140,3 +140,7 @@ class InvalidSyntaxError(PyCalcError):
 
 class ArgumentsError(PyCalcError):
     pass
+
+
+class NameNotFoundError(PyCalcError):
+    pass

--- a/pycalc/tokentypes/types.py
+++ b/pycalc/tokentypes/types.py
@@ -37,6 +37,7 @@ class TokenKind(enum.IntEnum):
     UNARY_OPERATOR = 3
     BRACE = 4
     FUNC = 5
+    OTHER = 6
 
 
 class TokenType(enum.IntEnum):
@@ -68,6 +69,7 @@ class TokenType(enum.IntEnum):
     FUNCCALL = 25
     FUNCDEF = 26
     FUNCNAME = 27
+    OTHER = 28
 
 
 OPERATORS_TABLE = {

--- a/pycalc/tokentypes/types.py
+++ b/pycalc/tokentypes/types.py
@@ -1,10 +1,10 @@
 import enum
 from string import ascii_letters
-from typing import Union, Dict, Tuple
+from typing import Union, Dict, Callable
 
 
 Number = Union[int, float]
-NamespaceValue = Union[Number, callable]
+NamespaceValue = Union[Number, Callable]
 Namespace = Dict[str, NamespaceValue]
 
 UNARY_OPERATORS = {"+", "-"}

--- a/pycalc/tokentypes/types.py
+++ b/pycalc/tokentypes/types.py
@@ -21,12 +21,13 @@ class LexemeType(enum.IntEnum):
     UNKNOWN = 0
     NUMBER = 1
     HEXNUMBER = 2
-    LITERAL = 3
-    OPERATOR = 4
-    LBRACE = 5
-    RBRACE = 6
-    DOT = 7
-    COMMA = 8
+    FLOAT = 3
+    LITERAL = 4
+    OPERATOR = 5
+    LBRACE = 6
+    RBRACE = 7
+    DOT = 8
+    COMMA = 9
 
 
 class TokenKind(enum.IntEnum):
@@ -39,33 +40,34 @@ class TokenKind(enum.IntEnum):
 
 
 class TokenType(enum.IntEnum):
-    NUMBER = -1
-    OP_EQ = 0
-    OP_EQEQ = 1
-    OP_NOTEQ = 2
-    OP_ADD = 3
-    OP_SUB = 4
-    OP_DIV = 5
-    OP_MUL = 6
-    OP_POW = 7
-    OP_LSHIFT = 8
-    OP_RSHIFT = 9
-    OP_BITWISE_AND = 10
-    OP_BITWISE_OR = 11
-    OP_BITWISE_XOR = 12
-    OP_MOD = 13
-    OP_FLOORDIV = 14
-    OP_SEMICOLON = 15
-    OP_COMMA = 16
-    UN_POS = 17
-    UN_NEG = 18
-    LBRACE = 19
-    RBRACE = 20
-    VAR = 21
-    IDENTIFIER = 22
-    FUNCCALL = 23
-    FUNCDEF = 24
-    FUNCNAME = 25
+    FLOAT = 0
+    INTEGER = 1
+    OP_EQ = 2
+    OP_EQEQ = 3
+    OP_NOTEQ = 4
+    OP_ADD = 5
+    OP_SUB = 6
+    OP_DIV = 7
+    OP_MUL = 8
+    OP_POW = 9
+    OP_LSHIFT = 10
+    OP_RSHIFT = 11
+    OP_BITWISE_AND = 12
+    OP_BITWISE_OR = 13
+    OP_BITWISE_XOR = 14
+    OP_MOD = 15
+    OP_FLOORDIV = 16
+    OP_SEMICOLON = 17
+    OP_COMMA = 18
+    UN_POS = 19
+    UN_NEG = 20
+    LBRACE = 21
+    RBRACE = 22
+    VAR = 23
+    IDENTIFIER = 24
+    FUNCCALL = 25
+    FUNCDEF = 26
+    FUNCNAME = 27
 
 
 OPERATORS_TABLE = {

--- a/std/__init__.py
+++ b/std/__init__.py
@@ -1,0 +1,1 @@
+from . import stdlibrary

--- a/std/stdio.py
+++ b/std/stdio.py
@@ -1,0 +1,10 @@
+from pycalc.tokentypes.types import ArgumentsError
+
+
+def print_(*floats) -> int:
+    if any(not num.is_integer() for num in floats):
+        raise ArgumentsError("print() takes only integers")
+
+    print(*[chr(int(num)) for num in floats], sep="", end="")
+
+    return 0

--- a/std/stdlibrary.py
+++ b/std/stdlibrary.py
@@ -1,0 +1,24 @@
+from math import pi, sqrt
+from functools import reduce
+
+from . import stdmem, stdstatements, stdio
+
+
+stdnamespace = {
+    "sqrt": sqrt,
+    "cbrt": lambda a, b: a ** (b/3),
+    "pi": pi,
+
+    "write": lambda target, value: target.write(value),
+    "print": stdio.print_,
+
+    "malloc": stdmem.mem_alloc,
+    "get": stdmem.mem_get,
+    "set": stdmem.mem_set,
+
+    "map": map,
+    "filter": filter,
+    "reduce": reduce,
+    "cond": stdstatements.cond,
+    "if": stdstatements.if_,
+}

--- a/std/stdmem.py
+++ b/std/stdmem.py
@@ -1,29 +1,18 @@
 from typing import List
 
-from pycalc.tokentypes.types import Number
+
+def mem_alloc(size: int) -> List[int]:
+    return [0] * size
 
 
-def mem_alloc(size: Number) -> List[int]:
-    if not size.is_integer():
-        raise TypeError("malloc() takes only integers")
-
-    return [0] * int(size)
-
-
-def mem_get(mem: List[int], offset: Number) -> int:
-    if not offset.is_integer():
-        raise TypeError("get() takes only integers")
-
+def mem_get(mem: List[int], offset: int) -> int:
     if 0 > offset >= len(mem):
         return -1
 
     return mem[int(offset)]
 
 
-def mem_set(mem: List[int], offset: Number, value: Number) -> int:
-    if not offset.is_integer() or not value.is_integer():
-        raise TypeError("set() takes only integers")
-
+def mem_set(mem: List[int], offset: int, value: int) -> int:
     if 0 > offset >= len(mem) or 0 > value > 255:
         return -1
 

--- a/std/stdmem.py
+++ b/std/stdmem.py
@@ -1,0 +1,31 @@
+from typing import List
+
+from pycalc.tokentypes.types import Number
+
+
+def mem_alloc(size: Number) -> List[int]:
+    if not size.is_integer():
+        raise TypeError("malloc() takes only integers")
+
+    return [0] * int(size)
+
+
+def mem_get(mem: List[int], offset: Number) -> int:
+    if not offset.is_integer():
+        raise TypeError("get() takes only integers")
+
+    if 0 > offset >= len(mem):
+        return -1
+
+    return mem[int(offset)]
+
+
+def mem_set(mem: List[int], offset: Number, value: Number) -> int:
+    if not offset.is_integer() or not value.is_integer():
+        raise TypeError("set() takes only integers")
+
+    if 0 > offset >= len(mem) or 0 > value > 255:
+        return -1
+
+    mem[int(offset)] = value
+    return 0

--- a/std/stdstatements.py
+++ b/std/stdstatements.py
@@ -1,0 +1,14 @@
+from typing import Callable
+
+from pycalc.tokentypes.types import Number
+
+
+def cond(condition: Callable, if_cb: Callable, else_cb: Callable) -> Number:
+    return if_cb() if condition() else else_cb()
+
+
+def if_(condition: Callable, cb: Callable):
+    if condition():
+        cb()
+
+    return 0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+from unittest import TestSuite
+
+from .testcases import evaluation_tests
+
+
+full_suite = TestSuite()
+full_suite.addTest(evaluation_tests)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,0 +1,8 @@
+import unittest
+
+from . import full_suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner(verbosity=2)
+    runner.run(full_suite)

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -1,13 +1,14 @@
-from math import pi, sqrt
+from math import pi
 from unittest import TestCase, TestSuite, makeSuite
 
+from pycalc.tokentypes.tokens import Function
 from pycalc.interpreter.interpret import Interpreter
 
 
 interpreter = Interpreter()
 basic_namespace = {
     "pi": pi,
-    "sqrt": sqrt
+    "rt": lambda a, b: a ** (1/b)
 }
 
 evaluate = lambda code: interpreter.interpret(code, basic_namespace)
@@ -115,11 +116,50 @@ class TestOperatorsPriority(TestCase):
         self.assertEqual(evaluate("-2**2"), -4)
 
 
-class TestEvaluation(TestCase):
-    pass
+class TestVariables(TestCase):
+    def test_get_pi(self):
+        self.assertEqual(evaluate("pi"), pi)
+
+    def test_negotate_pi(self):
+        self.assertEqual(evaluate("-pi"), -pi)
+
+    def test_expression_with_constant(self):
+        self.assertEqual(evaluate("pi+2.0-3"), pi + 2 - 3)
+        self.assertEqual(evaluate("2.0+pi-3"), 2 + pi - 3)
+        self.assertEqual(evaluate("2.0-3+pi"), 2 - 3 + pi)
+
+    def test_declare_var(self):
+        self.assertEqual(evaluate("a=5+5"), 10)
+
+    def test_get_declared_var(self):
+        self.assertEqual(evaluate("a"), 10)
+
+
+class TestFunctions(TestCase):
+    def test_funccall(self):
+        self.assertEqual(evaluate("rt(25, 2)"), 5)
+
+    def test_nested_funccall(self):
+        self.assertEqual(evaluate("rt(rt(625, 2), 2)"), 5)
+
+    def test_expr_in_funccall(self):
+        self.assertEqual(evaluate("rt(20+5, 1.0+1.0)"), 5)
+
+    def test_funcdef(self):
+        self.assertIsInstance(evaluate("f(x,y)=x*y"), Function)
+
+    def test_def_func_call(self):
+        evaluate("f(x,y)=x*y")
+        self.assertEqual(evaluate("f(2,5)"), 10)
+
+    def test_def_func_argexpr(self):
+        evaluate("f(x,y)=x*y")
+        self.assertEqual(evaluate("f(2+5, 3*2)"), 42)
 
 
 evaluation_tests = TestSuite()
 evaluation_tests.addTest(makeSuite(TestNumbers))
 evaluation_tests.addTest(makeSuite(TestBasicOperations))
 evaluation_tests.addTest(makeSuite(TestOperatorsPriority))
+evaluation_tests.addTest(makeSuite(TestVariables))
+evaluation_tests.addTest(makeSuite(TestFunctions))

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -1,0 +1,125 @@
+from math import pi, sqrt
+from unittest import TestCase, TestSuite, makeSuite
+
+from pycalc.interpreter.interpret import Interpreter
+
+
+interpreter = Interpreter()
+basic_namespace = {
+    "pi": pi,
+    "sqrt": sqrt
+}
+
+evaluate = lambda code: interpreter.interpret(code, basic_namespace)
+
+
+class TestNumbers(TestCase):
+    def test_integer(self):
+        self.assertEqual(evaluate("100"), 100)
+
+    def test_float(self):
+        self.assertEqual(evaluate("0.1"), 0.1)
+        self.assertEqual(evaluate(".1"), 0.1)
+
+
+class TestBasicOperations(TestCase):
+    def test_addition(self):
+        self.assertEqual(evaluate("1+1"), 2)
+
+    def test_subtraction(self):
+        self.assertEqual(evaluate("1-1"), 0)
+
+    def test_multiplication(self):
+        self.assertEqual(evaluate("1*1"), 1)
+
+    def test_division(self):
+        self.assertEqual(evaluate("1/2"), .5)
+
+    def test_floordivision(self):
+        self.assertEqual(evaluate("3//2"), 1)
+
+    def test_modulo(self):
+        self.assertEqual(evaluate("7%2"), 1)
+
+    def test_lshift(self):
+        self.assertEqual(evaluate("1<<5"), 32)
+
+    def test_rshift(self):
+        self.assertEqual(evaluate("128>>5"), 4)
+
+    def test_bitwise_and(self):
+        self.assertEqual(evaluate("32 & 64"), 0)
+
+    def test_bitwise_or(self):
+        self.assertEqual(evaluate("81 | 82"), 83)
+
+    def test_bitwise_xor(self):
+        self.assertEqual(evaluate("54^87"), 97)
+
+    def test_exponentiation(self):
+        self.assertEqual(evaluate("2**3"), 8)
+
+    def test_unary_addition(self):
+        self.assertEqual(evaluate("+1"), 1)
+
+    def test_unary_subtraction(self):
+        self.assertEqual(evaluate("-1"), -1)
+
+    def test_unary_subtraction_multiple(self):
+        self.assertEqual(evaluate("--1"), 1)
+        self.assertEqual(evaluate("---1"), -1)
+
+    def test_equality(self):
+        self.assertEqual(evaluate("2==2"), 1)
+        self.assertEqual(evaluate("2!=2"), 0)
+
+
+class TestOperatorsPriority(TestCase):
+    def test_addition_multiplication(self):
+        self.assertEqual(evaluate("2+2*2"), 6)
+
+    def test_addition_division(self):
+        self.assertEqual(evaluate("2+2/2"), 3)
+
+    def test_addition_exponentiation(self):
+        self.assertEqual(evaluate("1+2**3"), 9)
+
+    def test_subtraction_addition(self):
+        self.assertEqual(evaluate("1-2+3"), 2)
+
+    def test_subtraction_subtraction(self):
+        self.assertEqual(evaluate("1-2-3"), -4)
+
+    def test_subtraction_multiplication(self):
+        self.assertEqual(evaluate("2-2*2"), -2)
+
+    def test_subtraction_division(self):
+        self.assertEqual(evaluate("2-2/2"), 1)
+
+    def test_subtraction_exponentiation(self):
+        self.assertEqual(evaluate("1-2**3"), -7)
+
+    def test_multiplicaion_exponentiation(self):
+        self.assertEqual(evaluate("2*10**2"), 200)
+
+    def test_division_exponentiation(self):
+        self.assertEqual(evaluate("1/10**2"), 0.01)
+
+    def test_exponentiation_right_associativity(self):
+        self.assertEqual(evaluate("2**3**2"), 512)
+
+    def test_exponentiation_unary_subtraction(self):
+        self.assertEqual(evaluate("2^-3"), 0.125)
+
+    def test_unary_subtraction_exponentiation(self):
+        self.assertEqual(evaluate("-2**2"), -4)
+
+
+class TestEvaluation(TestCase):
+    pass
+
+
+evaluation_tests = TestSuite()
+evaluation_tests.addTest(makeSuite(TestNumbers))
+evaluation_tests.addTest(makeSuite(TestBasicOperations))
+evaluation_tests.addTest(makeSuite(TestOperatorsPriority))

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -109,7 +109,7 @@ class TestOperatorsPriority(TestCase):
         self.assertEqual(evaluate("2**3**2"), 512)
 
     def test_exponentiation_unary_subtraction(self):
-        self.assertEqual(evaluate("2^-3"), 0.125)
+        self.assertEqual(evaluate("2**-3"), 0.125)
 
     def test_unary_subtraction_exponentiation(self):
         self.assertEqual(evaluate("-2**2"), -4)

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -146,7 +146,17 @@ class TestFunctions(TestCase):
         self.assertEqual(evaluate("rt(20+5, 1.0+1.0)"), 5)
 
     def test_funcdef(self):
-        self.assertIsInstance(evaluate("f(x,y)=x*y"), Function)
+        func_a = evaluate("a()=5")
+        self.assertIsInstance(func_a, Function)
+        self.assertEqual(func_a.name, "a()")
+
+        func_b = evaluate("b(x)=x+1")
+        self.assertIsInstance(func_b, Function)
+        self.assertEqual(func_b.name, "b(x)")
+
+        func_c = evaluate("c(x,y)=x*y")
+        self.assertIsInstance(func_c, Function)
+        self.assertEqual(func_c.name, "c(x,y)")
 
     def test_def_func_call(self):
         evaluate("f(x,y)=x*y")
@@ -155,6 +165,24 @@ class TestFunctions(TestCase):
     def test_def_func_argexpr(self):
         evaluate("f(x,y)=x*y")
         self.assertEqual(evaluate("f(2+5, 3*2)"), 42)
+
+    def test_funcdef_argexpr(self):
+        with self.assertRaises(SyntaxError):
+            evaluate("f(x+1)=x+2")
+
+        with self.assertRaises(SyntaxError):
+            evaluate("f(1)=2")
+
+    def test_funcdef_missed_brace(self):
+        with self.assertRaises(SyntaxError):
+            evaluate("f(x=2")
+
+        with self.assertRaises(SyntaxError):
+            evaluate("fx)=2")
+
+    def test_funcdef_no_body(self):
+        with self.assertRaises(SyntaxError):
+            evaluate("f(x)=")
 
 
 evaluation_tests = TestSuite()


### PR DESCRIPTION
Updates, fixes and tests!
Today we have a huge PR. Changelog:
- Added information about higher-order functions
- Added namespaces mechanism based on chained dicts: now we have scopes!
- Now functions (external, of course) can return anything they want. In case no int or float was returned (bool counts as int), we add token with kind/type OTHER
- Improved functions defining: now `Function` object is returning. `Function` object just wraps original callable to define a `__str__` and `__repr__` dunders to avoid long and ugly prints in repl
- Separated integers from floats. Now integer has it's own type, just like float. In case of mixing them result will be a float
- Fixed unary operators in the beginning of an expression: instead of detecting them as operators, now they are detected as unary. As it had to be
- Added std library. Wow, now we have started forming the whole std library! Currently it contains not much but enough functions
- Added tests. Finally! Now we may be sure everything works fine after that small change (spoiler: everything is broken)