### PR TITLE
Megacalc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![wakatime](https://wakatime.com/badge/user/b4a2ea9a-a721-41c8-b704-79b9b8cec646/project/3e68a432-deec-4dab-ba8a-a5f424e91eed.svg)](https://wakatime.com/badge/user/b4a2ea9a-a721-41c8-b704-79b9b8cec646/project/3e68a432-deec-4dab-ba8a-a5f424e91eed)
 # pycalc
-Simple calculator on python, written in academic purposes. Uses Sorting Station Algorithm for building reverse polish notation stack. Supports all kinds of operations python supports (except bool operations like or, not, etc. but they will be implemented as a functions of std-library), functions defining, variables declarations, etc.
+Simple calculator on python, written in academic purposes. TURING-COMPLETE. Uses Sorting Station Algorithm for building reverse polish notation stack. Supports all kinds of operations python supports (except bool operations like or, not, etc. but they will be implemented as a functions of std-library), functions defining, variables declarations, etc.
 
 # How to install?
 ```bash

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -72,6 +72,34 @@ float(".5") == .5
 
 ---
 
+## `str`
+Semantic:
+```
+str(15.5)
+```
+Returns: string
+
+Examples:
+```
+str(.5) == "0.5"
+```
+
+---
+
+## `strjoin`
+Semantic:
+```
+strjoin(separator, mem)
+```
+Returns: single string
+
+Examples:
+```
+strjoin(".", "123") == "1.2.3"
+```
+
+---
+
 ## `range`
 Semantic:
 ```

--- a/examples/arrays.calc
+++ b/examples/arrays.calc
@@ -8,7 +8,7 @@ arrMake(size, bytesize) = malloc(size*bytesize)
 arrGet(arr, index, bytesize) =
     reduce(
         (x, y) = x + (y<<8),
-        slice(arr, index*bytesize, bytesize)
+        slice(arr, index*bytesize, index*bytesize+bytesize)
     )
 
 arrSet(arr, index, bytesize, value) =

--- a/examples/breakinggates.calc
+++ b/examples/breakinggates.calc
@@ -1,12 +1,10 @@
-print("1: ")
-src = input()
-print("2: ")
-modified = input()
+src = input("1: ")
+modified = input("2: ")
 
-count(mem, char) =
+count(string, char) =
     len(filter(
         (x) = x==char,
-        mem
+        string
     ))
 
 extra = 0
@@ -15,4 +13,4 @@ map(
         if(count(src, x) != count(modified, x), () = extra=x),
     modified
 )
-println(chr(extra))
+println(extra)

--- a/examples/turingmachine.calc
+++ b/examples/turingmachine.calc
@@ -1,0 +1,46 @@
+rulesMap(func, rules) =
+    map(
+        (x) = func(slice(rules, x, x+5)),
+        range(0, len(rules), 5)
+    )
+
+step(tape, rules, state, position) =
+    char = get(tape, position);
+    selectedRule = 0;
+    rulesMap(
+        (rule) = if(
+            (get(rule, 0) == state) + (get(rule, 1) == char) == 2,
+            () = selectedRule = rule
+        ),
+        rules
+    );
+    set(tape, position, get(selectedRule, 3));
+    moveHead = get(selectedRule, 4);
+    branch(
+        moveHead == 2,
+        () = position = position + 1,
+        moveHead == 1,
+        () = position = position - 1,
+    );
+    mallocfor(get(selectedRule, 2), position)
+
+
+rules = mallocfor(
+    1, ord("0"), 1, ord("1"), 2,
+    1, ord("1"), 1, ord("0"), 2,
+    1, ord("*"), 2, ord("*"), 1
+)
+tape = map(ord, "010011001*")
+println("tape was: ", strjoin("", map(chr, tape)))
+
+state = 1
+position = 0
+while(
+    () = state != 2,
+    () =
+        result = step(tape, rules, state, position);
+        state = get(result, 0);
+        position = get(result, 1)
+)
+
+println("tape became: ", strjoin("", map(chr, tape)))

--- a/pycalc/lex/tokenizer.py
+++ b/pycalc/lex/tokenizer.py
@@ -231,10 +231,13 @@ class Tokenizer(ABCTokenizer):
                 output.append(token)
 
         if buffer:
-            raise InvalidSyntaxError(
-                "unexpected operator in the end of the expression",
-                buffer[-1].pos
-            )
+            if len(buffer) == 1 and buffer[0].type == TokenType.OP_SEMICOLON:
+                output.append(buffer.pop())
+            else:
+                raise InvalidSyntaxError(
+                    "unexpected operator in the end of the expression",
+                    buffer[-1].pos
+                )
 
         return output
 

--- a/pycalc/tokentypes/types.py
+++ b/pycalc/tokentypes/types.py
@@ -181,5 +181,9 @@ class UnknownTokenError(PyCalcError):
     pass
 
 
+class ExternalFunctionError(PyCalcError):
+    pass
+
+
 class NoCodeError(Exception):
     pass

--- a/repl.py
+++ b/repl.py
@@ -93,7 +93,8 @@ def script_exec_mode(filename: str):
     except NoCodeError:
         pass
     except Exception as exc:
-        print(f"{fd.name}:?:?: internal interpreter error: {exc.__class__.__name__}({repr(exc)})")
+        print(f"{fd.name}:?:?: internal interpreter error:")
+        raise exc
 
 
 if __name__ == '__main__':

--- a/std/stdlibrary.py
+++ b/std/stdlibrary.py
@@ -18,6 +18,8 @@ stdnamespace = {
     "cbrt": lambda a: a ** (1/3),
     "int": int,
     "float": float,
+    "str": str,
+    "strjoin": str.join,
     "range": range,
     "inv": lambda a: ~a,
     "pi": pi,
@@ -35,7 +37,6 @@ stdnamespace = {
     "set": stdmem.mem_set,
     "slice": stdmem.slice_,
     "len": len,
-    "call": lambda func: func(),
 
     "map": _as_list(map),
     "filter": _as_list(filter),
@@ -43,4 +44,7 @@ stdnamespace = {
     "while": stdstatements.while_,
     "if": stdstatements.if_else,
     "branch": stdstatements.branch,
+
+    "nop": lambda: 0,
+    "call": lambda func: func(),
 }

--- a/std/stdmem.py
+++ b/std/stdmem.py
@@ -24,5 +24,5 @@ def mem_set(mem: List[int], offset: int, value: int) -> int:
     return 0
 
 
-def slice_(mem: List[int], begin: int, offset: int) -> List[int]:
-    return mem[begin:begin+offset]
+def slice_(mem: List[int], begin: int, end: int) -> List[int]:
+    return mem[begin:end]

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -150,7 +150,7 @@ class TestVariables(TestCase):
         self.assertEqual(evaluate("a=5+5"), 10)
 
     def test_get_declared_var(self):
-        self.assertEqual(evaluate("a"), 10)
+        self.assertEqual(evaluate("a=10 \n a"), 10)
 
 
 class TestFunctions(TestCase):
@@ -177,12 +177,10 @@ class TestFunctions(TestCase):
         self.assertEqual(func_c.name, "c(x,y)")
 
     def test_def_func_call(self):
-        evaluate("f(x,y)=x*y")
-        self.assertEqual(evaluate("f(2,5)"), 10)
+        self.assertEqual(evaluate("f(x,y)=x*y \n f(2,5)"), 10)
 
     def test_def_func_argexpr(self):
-        evaluate("f(x,y)=x*y")
-        self.assertEqual(evaluate("f(2+5, 3*2)"), 42)
+        self.assertEqual(evaluate("f(x,y)=x*y \n f(2+5, 3*2)"), 42)
 
     def test_funcdef_argexpr(self):
         with self.assertRaises(InvalidSyntaxError):
@@ -205,16 +203,14 @@ class TestFunctions(TestCase):
 
 class TestLambdas(TestCase):
     def test_assign_to_var(self):
-        func = evaluate("a=(x)=x+1")
-        self.assertIsInstance(func, Function)
-        self.assertEqual(evaluate("a(1)"), 2)
+        self.assertEqual(evaluate("a=(x)=x+1 \n a(1)"), 2)
 
     def test_lambda_as_argument(self):
-        sum_func = evaluate("sum(mem)=reduce((x,y)=x+y, mem)")
-        range_func = evaluate("range(begin, end) = i=begin-1; map((x)=i=i+1;x+i, malloc(end-begin))")
-        self.assertIsInstance(sum_func, Function)
-        self.assertIsInstance(range_func, Function)
-        self.assertEqual(evaluate("sum(range(0,5))"), 10)
+        self.assertEqual(evaluate("""
+        sum(mem)=reduce((x,y)=x+y, mem)
+        range(begin, end) = i=begin-1; map((x)=i=i+1;x+i, malloc(end-begin))
+        sum(range(0,5))
+        """), 10)
 
     def test_missing_brace_in_arglambda(self):
         with self.assertRaises(InvalidSyntaxError):


### PR DESCRIPTION
Changelog:
- Added methods: `str`, `strjoin`
- Updated examples due to ABI changes in `input` and `slice`
- Now global namespace is separated from std
- Lambda now has not empty name but `<lambda>`
- Fixed bug with counting function arguments
- Proofed Turing-completeness by writing a Turing-machine
- Minor fixes for `InvalidSyntaxError` in case only semicolon is left in buffer
- Added catching exceptions from external functions (like binds from pythons' functions or methods)
- Improved logging internal interpreter exceptions: now full traceback is shown for better issue with mre and traceback text